### PR TITLE
Add cross-platform Codex credential transfer scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Credential bundles should never be committed
+codex-auth-bundle.tar.gz
+codex-auth-bundle.tgz
+codex-auth-bundle.zip
+codex-auth-bundle-*.tar.gz
+codex-auth-bundle-*.tgz
+codex-auth-bundle-*.zip
+*.bak-*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# Codex Credential Export for Headless Machines
+
+This project provides portable, OS-specific scripts to export Codex CLI authentication data from a machine that can complete the browser login flow and restore it on a headless or remote host. The original one-off Linux script from [chuvadenovembro/script-to-use-codex-cli-on-remote-server-without-visual-environment](https://github.com/chuvadenovembro/script-to-use-codex-cli-on-remote-server-without-visual-environment) was generalized for macOS, Linux, and Windows with consistent behaviour and documentation.
+
+> ⚠️ **Security warning:** The exported bundle contains your Codex credentials. Treat it like a password manager backup: move it only over secure channels (SSH, SFTP, USB that you control) and delete it immediately after import.
+
+## Contents
+
+- [`scripts/linux/codex-auth-transfer.sh`](scripts/linux/codex-auth-transfer.sh) – Bash entry point for Linux systems.
+- [`scripts/macos/codex-auth-transfer.sh`](scripts/macos/codex-auth-transfer.sh) – Bash entry point tuned for macOS paths.
+- [`scripts/windows/CodexAuthTransfer.ps1`](scripts/windows/CodexAuthTransfer.ps1) – PowerShell entry point for Windows hosts.
+- [`scripts/shared/codex_auth_transfer.sh`](scripts/shared/codex_auth_transfer.sh) – Shared implementation used by the Unix scripts.
+
+All scripts generate the same archive layout so you can export on one platform and import on another.
+
+## What the scripts do
+
+1. **Detect Codex credential directories** using default Codex locations and `codex config path` when available.
+2. **Stage the data** in a temporary directory with restrictive permissions and write a manifest that records when the bundle was created.
+3. **Archive the staged files** to `codex-auth-bundle.tar.gz` (or a custom path) and set the resulting file to user-only access.
+4. **Restore bundles** on the target machine, optionally backing up any existing Codex data with a `.bak-YYYYmmdd-HHMMSS` suffix when `--force`/`-Force` is supplied.
+
+If a credential path lives outside the exporting user’s home directory it is added to the bundle under `.codex-external/<hash>` so nothing leaks about the original absolute path.
+
+## Prerequisites
+
+| Platform | Requirements |
+| --- | --- |
+| Linux | Bash 4+, `tar`, and optionally `rsync` (for faster copies). |
+| macOS | Bash (the system `/bin/bash` works), `tar`, and optionally `rsync`. |
+| Windows | PowerShell 5.1 or later, `tar.exe` (ships with Windows 10 build 17063+), and `robocopy` (included with Windows). |
+
+Ensure the Codex CLI is installed and signed in on the source machine. The target machine only needs the CLI installed; the scripts copy the credential files.
+
+## Usage overview
+
+1. **Export on a machine with browser access.**
+2. **Transfer the generated `codex-auth-bundle.tar.gz`** to the target machine over a secure channel.
+3. **Import on the headless/remote machine.**
+4. **Remove the bundle from both machines** once the CLI works.
+
+### Linux
+
+```bash
+# Source machine (already logged into Codex CLI)
+chmod +x scripts/linux/codex-auth-transfer.sh
+./scripts/linux/codex-auth-transfer.sh export
+
+# Target machine
+chmod +x scripts/linux/codex-auth-transfer.sh
+./scripts/linux/codex-auth-transfer.sh import --force
+```
+
+Use `--force` when you want existing Codex directories to be backed up and replaced. Supply a custom archive name with `--output <path>` or `--file <path>` as needed.
+
+### macOS
+
+```bash
+# Source machine
+chmod +x scripts/macos/codex-auth-transfer.sh
+./scripts/macos/codex-auth-transfer.sh export --output ~/Desktop/codex-auth-bundle.tar.gz
+
+# Target machine
+chmod +x scripts/macos/codex-auth-transfer.sh
+./scripts/macos/codex-auth-transfer.sh import --file ~/codex-auth-bundle.tar.gz --force
+```
+
+The macOS script searches both standard Unix locations (`~/.config/codex`, `~/.codex`) and macOS-specific application support folders under `~/Library/Application Support`.
+
+### Windows
+
+```powershell
+# Source machine (PowerShell)
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\scripts\windows\CodexAuthTransfer.ps1 export -Output C:\Users\me\Desktop\codex-auth-bundle.tar.gz
+
+# Target machine (PowerShell, bundle copied in advance)
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\scripts\windows\CodexAuthTransfer.ps1 import -File C:\Users\me\Downloads\codex-auth-bundle.tar.gz -Force
+```
+
+The PowerShell script requires `tar.exe` in `PATH`. On modern Windows 10/11 installations it is preinstalled. If `tar.exe` is missing, install the “Windows Subsystem for Linux” feature or the free [bsdtar](https://github.com/libarchive/libarchive/releases) binary and add it to your `%PATH%`.
+
+### Optional flags
+
+- `CODEX_AUTH_TRANSFER_NO_METADATA=1` (Linux/macOS) or `-NoMetadata` (Windows) skips recording the `user=` and `host=` fields in the manifest.
+- `--output`/`-Output` chooses a different bundle destination.
+- `--file`/`-File` selects a different bundle when importing.
+- `--force`/`-Force` backs up and overwrites existing credential folders on the target machine.
+
+## Post-import checks
+
+After importing:
+
+1. Run `codex whoami` or another harmless CLI command to confirm the credentials work.
+2. Delete the transferred bundle from all machines (`shred -u` on Linux, `srm` on macOS if available, or `Remove-Item` in PowerShell).
+3. Remove any `.bak-*` backups if the new credentials work and you no longer need the old ones.
+
+## Troubleshooting
+
+- **`No Codex credential directories were found.`** Ensure you have signed in with `codex login` on the source machine and rerun the export.
+- **Import fails because destinations exist.** Re-run the import with `--force`/`-Force`. The scripts safely move the old directories to `<path>.bak-YYYYmmdd-HHMMSS` before replacing them.
+- **Codex refuses the restored credentials.** Some tokens are host-specific. Use a secure tunnel (e.g., SSH port forwarding) or the CLI’s device code login on the remote machine instead.
+- **Windows complains about execution policy.** Use `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` in the session or sign the script with a trusted certificate.
+
+## Development notes
+
+- The Unix scripts share the implementation in [`scripts/shared/codex_auth_transfer.sh`](scripts/shared/codex_auth_transfer.sh) to keep behaviour identical between Linux and macOS.
+- `rsync` is preferred when available because it preserves permissions efficiently. When `rsync` is absent the scripts fall back to `cp -a` (Unix) or `Copy-Item` (Windows).
+- Archives are always gzip-compressed tarballs so you can export on one operating system and import on another without conversion.
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/scripts/linux/codex-auth-transfer.sh
+++ b/scripts/linux/codex-auth-transfer.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../shared/codex_auth_transfer.sh"
+
+codex_auth_transfer_main "linux" "$@"

--- a/scripts/macos/codex-auth-transfer.sh
+++ b/scripts/macos/codex-auth-transfer.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../shared/codex_auth_transfer.sh"
+
+codex_auth_transfer_main "macos" "$@"

--- a/scripts/shared/codex_auth_transfer.sh
+++ b/scripts/shared/codex_auth_transfer.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Shared implementation for Codex credential export/import.
+# Exposes codex_auth_transfer_main which expects the first argument
+# to indicate the operating system (linux|macos) followed by the
+# regular CLI arguments.
+
+# shellcheck shell=bash
+
+PROGRAM_NAME="codex-auth-transfer"
+DEFAULT_BUNDLE_NAME="codex-auth-bundle.tar.gz"
+
+codex_auth_transfer::log() {
+  printf '[%s] %s\n' "$PROGRAM_NAME" "$*"
+}
+
+codex_auth_transfer::err() {
+  printf '[%s][ERROR] %s\n' "$PROGRAM_NAME" "$*" 1>&2
+}
+
+codex_auth_transfer::usage() {
+  cat <<'USAGE'
+Usage:
+  codex-auth-transfer.sh export [-o <bundle>]
+  codex-auth-transfer.sh import [-f <bundle>] [--force]
+
+Options:
+  export            Create an archive with Codex CLI credentials.
+  import            Restore credentials from a bundle into the current HOME.
+  -o, --output      Name of the bundle to generate (default: codex-auth-bundle.tar.gz).
+  -f, --file        Bundle file to restore from (default: codex-auth-bundle.tar.gz).
+  --force           Backup and overwrite destinations if they already exist.
+  -h, --help        Show this help message.
+
+Environment:
+  CODEX_AUTH_TRANSFER_NO_METADATA=1  Skip recording user/host metadata in manifest.
+USAGE
+}
+
+codex_auth_transfer::timestamp() {
+  date +%Y%m%d-%H%M%S
+}
+
+codex_auth_transfer::mktemp_dir() {
+  local tmp
+  if tmp=$(mktemp -d 2>/dev/null); then
+    printf '%s\n' "$tmp"
+    return 0
+  fi
+  # macOS' mktemp requires a template.
+  tmp=$(mktemp -d -t codex-auth-transfer)
+  printf '%s\n' "$tmp"
+}
+
+codex_auth_transfer::hash_path() {
+  local path="$1"
+  if command -v sha1sum >/dev/null 2>&1; then
+    printf '%s' "$path" | sha1sum | awk '{print $1}'
+  else
+    printf '%s' "$path" | shasum | awk '{print $1}'
+  fi
+}
+
+codex_auth_transfer::collect_candidates() {
+  local os_hint="$1"
+  local home="$HOME"
+  local base_config base_data
+  local -a candidates=()
+
+  case "$os_hint" in
+    linux)
+      base_config="${XDG_CONFIG_HOME:-$home/.config}"
+      base_data="${XDG_DATA_HOME:-$home/.local/share}"
+      candidates+=("$base_config/codex" "$base_data/codex" "$home/.codex")
+      ;;
+    macos)
+      base_config="${XDG_CONFIG_HOME:-$home/.config}"
+      base_data="${XDG_DATA_HOME:-$home/Library/Application Support}" # fallback to mac convention
+      candidates+=(
+        "$base_config/codex"
+        "$home/Library/Application Support/Codex"
+        "$home/Library/Application Support/OpenAI"
+        "$home/Library/Application Support/com.openai.codex"
+        "$home/.codex"
+      )
+      ;;
+    *)
+      codex_auth_transfer::err "Unknown OS hint: $os_hint"
+      return 1
+      ;;
+  esac
+
+  if command -v codex >/dev/null 2>&1; then
+    local hinted
+    hinted=$(codex config path 2>/dev/null || true)
+    if [ -n "${hinted:-}" ] && [ -d "$hinted" ]; then
+      candidates=("$hinted" "${candidates[@]}")
+    fi
+  fi
+
+  local path existing=() found prev
+  for path in "${candidates[@]}"; do
+    [ -z "$path" ] && continue
+    if [ -e "$path" ]; then
+      found=0
+      for prev in "${existing[@]}"; do
+        if [ "$prev" = "$path" ]; then
+          found=1
+          break
+        fi
+      done
+      [ "$found" -eq 1 ] && continue
+      existing+=("$path")
+    fi
+  done
+
+  for path in "${existing[@]}"; do
+    printf '%s\n' "$path"
+  done
+}
+
+codex_auth_transfer::normalize_bundle_path() {
+  local bundle="$1"
+  if [ -z "$bundle" ]; then
+    printf '%s\n' "$PWD/$DEFAULT_BUNDLE_NAME"
+    return 0
+  fi
+  local dir base
+  dir=$(dirname -- "$bundle")
+  base=$(basename -- "$bundle")
+  if [ "$dir" = "." ]; then
+    printf '%s/%s\n' "$PWD" "$base"
+  else
+    (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$PWD" "$base")
+  fi
+}
+
+codex_auth_transfer::stage_paths() {
+  local os_hint="$1"
+  local stage_dir="$2"
+  local list_file="$3"
+
+  local -a paths=()
+  while IFS= read -r line; do
+    [ -n "$line" ] && paths+=("$line")
+  done < <(codex_auth_transfer::collect_candidates "$os_hint")
+
+  if [ "${#paths[@]}" -eq 0 ]; then
+    codex_auth_transfer::err "No Codex credential directories were found."
+    return 1
+  fi
+
+  codex_auth_transfer::log "Detected credential locations:" "$os_hint"
+  local p
+  for p in "${paths[@]}"; do
+    codex_auth_transfer::log "  - $p"
+  done
+
+  : > "$list_file"
+
+  local rel dest hash
+  for p in "${paths[@]}"; do
+    if [ "${p#"$HOME"/}" != "$p" ]; then
+      rel=".${p#"$HOME"}"
+    else
+      hash=$(codex_auth_transfer::hash_path "$p")
+      rel=".codex-external/$hash"
+    fi
+
+    dest="$stage_dir/$rel"
+    mkdir -p "$(dirname -- "$dest")"
+
+    if [ -d "$p" ]; then
+      mkdir -p "$dest"
+      if command -v rsync >/dev/null 2>&1; then
+        rsync -a --chmod=Du+rwx,Fu+rw "$p/" "$dest/"
+      else
+        cp -a "$p/." "$dest/"
+        find "$dest" -type d -exec chmod 700 {} +
+        find "$dest" -type f -exec chmod 600 {} +
+      fi
+    else
+      mkdir -p "$(dirname -- "$dest")"
+      cp "$p" "$dest"
+      chmod 600 "$dest" 2>/dev/null || true
+    fi
+
+    printf '%s\n' "$rel" >> "$list_file"
+  done
+}
+
+codex_auth_transfer::write_manifest() {
+  local stage_dir="$1"
+  local manifest="$stage_dir/.codex_auth_manifest"
+
+  {
+    printf 'created_at=%s\n' "$(date -Iseconds)"
+    printf 'paths_file=%s\n' ".codex_auth_paths.txt"
+    if [ "${CODEX_AUTH_TRANSFER_NO_METADATA:-0}" != "1" ]; then
+      printf 'user=%s\n' "${USER:-}"
+      printf 'host=%s\n' "$(hostname -f 2>/dev/null || hostname)"
+    fi
+  } > "$manifest"
+}
+
+codex_auth_transfer::backup_path() {
+  local target="$1"
+  if [ -e "$target" ]; then
+    local backup="${target}.bak-$(codex_auth_transfer::timestamp)"
+    codex_auth_transfer::log "Backing up existing path: $target -> $backup"
+    mv "$target" "$backup"
+  fi
+}
+
+codex_auth_transfer::enforce_permissions() {
+  local path="$1"
+  find "$path" -type d -exec chmod 700 {} +
+  find "$path" -type f -exec chmod 600 {} +
+}
+
+codex_auth_transfer::do_export() {
+  local os_hint="$1"
+  local bundle_path
+  bundle_path=$(codex_auth_transfer::normalize_bundle_path "$2")
+
+  local tmpdir stage listfile
+  tmpdir=$(codex_auth_transfer::mktemp_dir)
+  stage="$tmpdir/stage"
+  mkdir -p "$stage"
+  listfile="$stage/.codex_auth_paths.txt"
+
+  trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+  codex_auth_transfer::stage_paths "$os_hint" "$stage" "$listfile"
+
+  codex_auth_transfer::write_manifest "$stage"
+
+  (cd "$stage" && tar -czf "$bundle_path" .)
+  chmod 600 "$bundle_path" 2>/dev/null || true
+
+  codex_auth_transfer::log "Bundle created at $bundle_path"
+  codex_auth_transfer::log "Transfer it over a secure channel only."
+}
+
+codex_auth_transfer::read_list_file() {
+  local tmpdir="$1"
+  local listfile="$tmpdir/.codex_auth_paths.txt"
+  if [ ! -f "$listfile" ]; then
+    codex_auth_transfer::log "Path list missing; attempting to infer from archive contents..."
+    (cd "$tmpdir" && find . -maxdepth 3 -type d \
+      \( -path './.config/codex' -o -path './.local/share/codex' \
+         -o -path './.codex' -o -path './.codex-external/*' \) \
+      | sed 's|^./||') > "$listfile"
+  fi
+  if [ ! -s "$listfile" ]; then
+    codex_auth_transfer::err "No credential paths found in bundle."
+    return 1
+  fi
+  printf '%s\n' "$listfile"
+}
+
+codex_auth_transfer::do_import() {
+  local os_hint="$1"
+  local bundle_path
+  bundle_path=$(codex_auth_transfer::normalize_bundle_path "$2")
+  local force_flag="$3"
+
+  if [ ! -f "$bundle_path" ]; then
+    codex_auth_transfer::err "Bundle not found: $bundle_path"
+    return 1
+  fi
+
+  local tmpdir
+  tmpdir=$(codex_auth_transfer::mktemp_dir)
+  trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+  codex_auth_transfer::log "Extracting bundle $bundle_path ..."
+  tar -xzf "$bundle_path" -C "$tmpdir"
+
+  local listfile
+  listfile=$(codex_auth_transfer::read_list_file "$tmpdir")
+
+  codex_auth_transfer::log "Restoring credential directories:"
+  while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    codex_auth_transfer::log "  - $rel"
+    local src="$tmpdir/$rel"
+    local dest="$HOME/$rel"
+
+    mkdir -p "$(dirname -- "$dest")"
+    if [ -e "$dest" ]; then
+      if [ "$force_flag" = "1" ]; then
+        codex_auth_transfer::backup_path "$dest"
+      else
+        codex_auth_transfer::err "Destination already exists: $dest"
+        codex_auth_transfer::err "Re-run with --force to backup and overwrite."
+        return 1
+      fi
+    fi
+
+    mkdir -p "$dest"
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --chmod=Du+rwx,Fu+rw "$src/" "$dest/"
+    else
+      cp -a "$src/." "$dest/"
+    fi
+
+    codex_auth_transfer::enforce_permissions "$dest"
+  done < "$listfile"
+
+  codex_auth_transfer::log "Credentials restored under $HOME."
+  codex_auth_transfer::log "If Codex rejects the tokens, re-run login via secure channel."
+}
+
+codex_auth_transfer_main() {
+  local os_hint="$1"
+  shift || true
+
+  local cmd=""
+  local bundle=""
+  local force=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      export|import)
+        cmd="$1"
+        shift
+        ;;
+      -o|--output)
+        bundle="$2"
+        shift 2
+        ;;
+      -f|--file)
+        bundle="$2"
+        shift 2
+        ;;
+      --force)
+        force=1
+        shift
+        ;;
+      -h|--help)
+        codex_auth_transfer::usage
+        return 0
+        ;;
+      *)
+        codex_auth_transfer::err "Unknown option: $1"
+        codex_auth_transfer::usage
+        return 1
+        ;;
+    esac
+  done
+
+  if [ -z "$cmd" ]; then
+    codex_auth_transfer::usage
+    return 1
+  fi
+
+  if [ -z "$bundle" ]; then
+    bundle="$DEFAULT_BUNDLE_NAME"
+  fi
+
+  case "$cmd" in
+    export)
+      codex_auth_transfer::do_export "$os_hint" "$bundle"
+      ;;
+    import)
+      codex_auth_transfer::do_import "$os_hint" "$bundle" "$force"
+      ;;
+  esac
+}

--- a/scripts/windows/CodexAuthTransfer.ps1
+++ b/scripts/windows/CodexAuthTransfer.ps1
@@ -1,0 +1,280 @@
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet('export', 'import')]
+    [string]$Command,
+
+    [string]$Output,
+
+    [string]$File,
+
+    [switch]$Force,
+
+    [switch]$NoMetadata
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$ProgramName = 'codex-auth-transfer'
+$DefaultBundle = 'codex-auth-bundle.tar.gz'
+
+function Write-Log {
+    param([string]$Message)
+    Write-Host "[$ProgramName] $Message"
+}
+
+function New-TemporaryDirectory {
+    $path = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
+    return (New-Item -ItemType Directory -Path $path -Force).FullName
+}
+
+function Get-PathHash {
+    param([string]$Path)
+    $sha1 = [System.Security.Cryptography.SHA1]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($Path)
+        $hashBytes = $sha1.ComputeHash($bytes)
+        ($hashBytes | ForEach-Object { $_.ToString('x2') }) -join ''
+    } finally {
+        $sha1.Dispose()
+    }
+}
+
+function Get-CodexCandidatePaths {
+    $paths = @()
+    $home = $env:USERPROFILE
+    if ($env:APPDATA) { $paths += (Join-Path $env:APPDATA 'codex') }
+    if ($env:LOCALAPPDATA) { $paths += (Join-Path $env:LOCALAPPDATA 'codex') }
+    if ($home) {
+        $paths += (Join-Path $home '.codex')
+        $paths += (Join-Path $home 'AppData\Roaming\codex')
+        $paths += (Join-Path $home 'AppData\Local\codex')
+    }
+
+    try {
+        $codexPath = (& codex config path 2>$null)
+        if ($codexPath -and (Test-Path -LiteralPath $codexPath)) {
+            $paths = ,$codexPath + $paths
+        }
+    } catch {
+        # codex CLI may not be available
+    }
+
+    $result = @()
+    foreach ($p in $paths) {
+        if ([string]::IsNullOrWhiteSpace($p)) { continue }
+        if (-not (Test-Path -LiteralPath $p)) { continue }
+        if ($result -contains $p) { continue }
+        $result += $p
+    }
+    return $result
+}
+
+function Resolve-BundlePath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $Path = $DefaultBundle
+    }
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        try {
+            return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+        } catch {
+            return $Path
+        }
+    }
+    return (Join-Path -Path (Get-Location) -ChildPath $Path)
+}
+
+function Require-Tar {
+    $tar = Get-Command tar -ErrorAction SilentlyContinue
+    if (-not $tar) {
+        throw "tar.exe was not found. Install the Windows tar utility (available in Windows 10 build 17063+) or add it to PATH."
+    }
+    return $tar.Source
+}
+
+function Convert-ToRelativePath {
+    param([string]$FullPath, [string]$Home)
+    $normalizedHome = [System.IO.Path]::GetFullPath($Home)
+    $normalizedFull = [System.IO.Path]::GetFullPath($FullPath)
+    if ($normalizedFull.StartsWith($normalizedHome, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $suffix = $normalizedFull.Substring($normalizedHome.Length).TrimStart('\', '/')
+        return '.{0}' -f ($suffix -replace '\\', '/')
+    }
+    $hash = Get-PathHash -Path $normalizedFull
+    return ".codex-external/$hash"
+}
+
+function Convert-ToSystemPath {
+    param([string]$Root, [string]$Relative)
+    $winRel = $Relative -replace '/', '\\'
+    return [System.IO.Path]::GetFullPath((Join-Path -Path $Root -ChildPath $winRel))
+}
+
+function Copy-CodexItem {
+    param([string]$Source, [string]$Destination)
+    if (Test-Path -LiteralPath $Source -PathType Container) {
+        New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+        $args = @($Source, $Destination, '/MIR', '/COPY:DAT', '/R:2', '/W:2', '/NFL', '/NDL', '/NJH', '/NJS', '/NP')
+        & robocopy @args | Out-Null
+        if ($LASTEXITCODE -gt 7) {
+            throw "robocopy failed with exit code $LASTEXITCODE while copying $Source"
+        }
+    } else {
+        New-Item -ItemType Directory -Path (Split-Path -Parent $Destination) -Force | Out-Null
+        Copy-Item -LiteralPath $Source -Destination $Destination -Force
+    }
+}
+
+function Protect-Path {
+    param([string]$Path)
+    try {
+        & icacls "$Path" /inheritance:r /grant:r "$env:USERNAME:(OI)(CI)F" "SYSTEM:(OI)(CI)F" | Out-Null
+    } catch {
+        Write-Warning "Failed to tighten permissions on $Path: $_"
+    }
+}
+
+function Stage-CodexData {
+    param([string]$StageDir, [string]$ListFile)
+    $paths = Get-CodexCandidatePaths
+    if (-not $paths -or $paths.Count -eq 0) {
+        throw 'No Codex credential directories were found.'
+    }
+    Write-Log 'Detected credential locations:'
+    foreach ($p in $paths) { Write-Log "  - $p" }
+
+    Set-Content -Path $ListFile -Value @() -Encoding UTF8
+
+    foreach ($p in $paths) {
+        $rel = Convert-ToRelativePath -FullPath $p -Home $env:USERPROFILE
+        $dest = Convert-ToSystemPath -Root $StageDir -Relative $rel
+        Copy-CodexItem -Source $p -Destination $dest
+        Add-Content -Path $ListFile -Value $rel
+    }
+}
+
+function Write-Manifest {
+    param([string]$StageDir)
+    $manifestPath = Join-Path $StageDir '.codex_auth_manifest'
+    $lines = @()
+    $lines += "created_at=$(Get-Date -Format o)"
+    $lines += 'paths_file=.codex_auth_paths.txt'
+    if (-not $NoMetadata.IsPresent) {
+        $lines += "user=$env:USERNAME"
+        $lines += "host=$env:COMPUTERNAME"
+    }
+    Set-Content -Path $manifestPath -Value $lines -Encoding UTF8
+}
+
+function Invoke-Export {
+    $bundlePath = Resolve-BundlePath -Path $Output
+    $tarPath = Require-Tar
+    $tmpDir = New-TemporaryDirectory
+    $stageDir = Join-Path $tmpDir 'stage'
+    New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
+    $listFile = Join-Path $stageDir '.codex_auth_paths.txt'
+    try {
+        Stage-CodexData -StageDir $stageDir -ListFile $listFile
+        Write-Manifest -StageDir $stageDir
+        Push-Location $stageDir
+        try {
+            & $tarPath -czf "$bundlePath" .
+            if ($LASTEXITCODE -ne 0) {
+                throw "tar exited with code $LASTEXITCODE"
+            }
+        } finally {
+            Pop-Location
+        }
+        Protect-Path -Path $bundlePath
+        Write-Log "Bundle created at $bundlePath"
+        Write-Log 'Transfer it only over secure channels.'
+    } finally {
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-ListFile {
+    param([string]$TempDir)
+    $listPath = Join-Path $TempDir '.codex_auth_paths.txt'
+    if (-not (Test-Path -LiteralPath $listPath)) {
+        Write-Log 'Path list missing; inferring from archive contents...'
+        $candidates = @()
+        $targets = @('.config/codex', '.local/share/codex', '.codex')
+        foreach ($t in $targets) {
+            $candidate = Convert-ToSystemPath -Root $TempDir -Relative $t
+            if (Test-Path -LiteralPath $candidate) {
+                $candidates += $t
+            }
+        }
+        $externalRoot = Convert-ToSystemPath -Root $TempDir -Relative '.codex-external'
+        if (Test-Path -LiteralPath $externalRoot) {
+            $candidates += (Get-ChildItem -LiteralPath $externalRoot -Directory | ForEach-Object { ".codex-external/$($_.Name)" })
+        }
+        if ($candidates.Count -gt 0) {
+            Set-Content -Path $listPath -Value ($candidates | Sort-Object -Unique) -Encoding UTF8
+        }
+    }
+    if (-not (Test-Path -LiteralPath $listPath)) {
+        throw 'No credential paths found in bundle.'
+    }
+    return $listPath
+}
+
+function Backup-IfExists {
+    param([string]$Target)
+    if (Test-Path -LiteralPath $Target) {
+        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $backup = "$Target.bak-$timestamp"
+        Write-Log "Backing up existing path: $Target -> $backup"
+        Move-Item -LiteralPath $Target -Destination $backup -Force
+    }
+}
+
+function Invoke-Import {
+    $bundlePath = Resolve-BundlePath -Path $File
+    if (-not (Test-Path -LiteralPath $bundlePath)) {
+        throw "Bundle not found: $bundlePath"
+    }
+    $tarPath = Require-Tar
+    $tmpDir = New-TemporaryDirectory
+    try {
+        Write-Log "Extracting bundle $bundlePath ..."
+        & $tarPath -xzf "$bundlePath" -C "$tmpDir"
+        if ($LASTEXITCODE -ne 0) {
+            throw "tar exited with code $LASTEXITCODE"
+        }
+        $listFile = Get-ListFile -TempDir $tmpDir
+        $paths = Get-Content -Path $listFile | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        if (-not $paths -or $paths.Count -eq 0) {
+            throw 'No credential paths found in bundle.'
+        }
+        Write-Log 'Restoring credential directories:'
+        foreach ($rel in $paths) {
+            Write-Log "  - $rel"
+            $src = Convert-ToSystemPath -Root $tmpDir -Relative $rel
+            $dest = Convert-ToSystemPath -Root $env:USERPROFILE -Relative $rel
+            New-Item -ItemType Directory -Path (Split-Path -Parent $dest) -Force | Out-Null
+            if (Test-Path -LiteralPath $dest) {
+                if ($Force.IsPresent) {
+                    Backup-IfExists -Target $dest
+                } else {
+                    throw "Destination already exists: $dest. Re-run with -Force to overwrite."
+                }
+            }
+            Copy-CodexItem -Source $src -Destination $dest
+            Protect-Path -Path $dest
+        }
+        Write-Log "Credentials restored under $env:USERPROFILE."
+        Write-Log 'If Codex rejects the tokens, perform login using a secure tunnel or device code.'
+    } finally {
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+switch ($Command) {
+    'export' { Invoke-Export }
+    'import' { Invoke-Import }
+    default { throw "Unknown command: $Command" }
+}


### PR DESCRIPTION
## Summary
- add a shared bash implementation that safely exports/imports Codex CLI credentials
- provide Linux and macOS entry-point scripts plus a Windows PowerShell workflow to create/import bundles
- document usage for all platforms and ignore generated credential bundles

## Testing
- bash -n scripts/shared/codex_auth_transfer.sh
- bash -n scripts/linux/codex-auth-transfer.sh
- bash -n scripts/macos/codex-auth-transfer.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca4e636e40832291380d99845ca8a1